### PR TITLE
sudo to remove riscv toolchain

### DIFF
--- a/patch/patch_toolchain.sh
+++ b/patch/patch_toolchain.sh
@@ -59,7 +59,7 @@ sudo make
 # Removing the submodule
 msg "${RED}> Cleaning toolchain${NOFORMAT}"
 cd ..
-rm -rf riscv-gnu-toolchain/*
+sudo rm -rf riscv-gnu-toolchain/*
 git submodule deinit -f riscv-gnu-toolchain
 
 msg "${GREEEN}> Toolchain patched!!${NOFORMAT}"


### PR DESCRIPTION
Before thinking about removing this line, it won't work if we don't add `sudo`.
As we do `sudo make` before that, files are generated with `root` ownership.